### PR TITLE
different handling of the sample metrics thingy

### DIFF
--- a/LIMS2DB/objectsDB/objectsDB.py
+++ b/LIMS2DB/objectsDB/objectsDB.py
@@ -412,7 +412,7 @@ class SampleDB():
                     if key:
                         lims_run = Process(self.lims, id = steps.lastseq['id'])
                         run_dict = dict(lims_run.udf.items())
-                        if preps.get(key, {}).has_key('reagent_label') and run_dict.has_key('Finish Date'):
+                        if preps.get(key, {}).has_key('reagent_label') and run_dict.has_key('Run ID'):
                             try:
                                 dem_art = Artifact(self.lims, id = steps.latestdem['outart'])
                                 dem_qc = dem_art.qc_flag
@@ -430,7 +430,10 @@ class SampleDB():
                                                                  samp_run_met_id)
                                 dpsd = steps.dilstart['date'] if steps.dilstart else None
                                 ssd = steps.seqstart['date'] if steps.seqstart else None
-                                sfd = lims_run.udf['Finish Date'].isoformat()
+                                if 'Finish Date' in lims_run.udf :
+                                    sfd = lims_run.udf['Finish Date'].isoformat()
+                                else:
+                                    sfd=None
                                 d = {'sample_run_metrics_id' : srmi,
                                     'dillution_and_pooling_start_date' : dpsd,
                                     'sequencing_start_date' : ssd,

--- a/LIMS2DB/objectsDB/process_categories.py
+++ b/LIMS2DB/objectsDB/process_categories.py
@@ -42,7 +42,8 @@ PREPSTART = {'Description':'Process/processes that can be defined as a start of 
     '308': 'Library Pooling (TruSeq Small RNA) 1.0',
     '117' : 'Applications Generic Process',
     '454' : 'ThruPlex template preparation and synthesis',
-    '405' : 'RiboZero depletion'}
+    '405' : 'RiboZero depletion',
+    '605' : 'Tagmentation, Strand displacement and AMPure purification'}
 PREPEND = {'Description':'Process that can be defined as a end of the library preparation. If more than one library preparation protocol is included in the work flow, only the prep end step of the second protocol should be given here. Used to set the prep finished date.',
     '157': 'Applications Finish Prep',
     '109' : 'CA Purification',


### PR DESCRIPTION
I want the sample_run_metrics object even if theres no finish date, but I want it only if I have a run id.