### PR TITLE
Skip reagent labels and other changes to PSUL

### DIFF
--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -941,7 +941,7 @@ class ProjectSQL:
                                 self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['sequencing_start_date'] = seqstarts[0].daterun.strftime("%Y-%m-%d")
                             except AttributeError:
                                 self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['sequencing_start_date'] = seqstarts[0].createddate.strftime("%Y-%m-%d")
-                            self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['sample_run_metrics_id'] = self.find_couch_sampleid(samp_run_met_id)
+                            self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['sample_run_metrics_id'] = None  # Deprecated
                             try:
                                 self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['dillution_and_pooling_start_date'] = dilstarts[0].daterun.strftime("%Y-%m-%d")
                             except AttributeError:
@@ -1008,9 +1008,3 @@ class ProjectSQL:
             if matches:
                 barcode = matches.group(0).replace('_','-')
         return barcode
-
-    def find_couch_sampleid(self, sample_run):
-        db = self.couch['samples']
-        view = db.view('names/name_to_id')
-        for row in view[sample_run]:
-            return row.id

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -418,6 +418,8 @@ class ProjectSQL:
                     self.obj['staged_files'] = my_staged_files
                 self.log.info("Trying to save new doc for project {}".format(self.pid))
                 db.save(self.obj)
+            else:
+                self.log.info("No modifications found for project {}".format(self.pid))
 
         else:
             self.obj['creation_time'] = datetime.now().isoformat()

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -769,7 +769,6 @@ class ProjectSQL:
                         self.obj['samples'][sample.name]['library_prep'][prepname]['library_validation'][agrlibval.luid]['prep_status'] = inp_artifact.qc_flag
                         self.obj['samples'][sample.name]['library_prep'][prepname]['prep_status'] = inp_artifact.qc_flag
                         self.obj['samples'][sample.name]['library_prep'][prepname]['library_validation'][agrlibval.luid]['well_location'] = inp_artifact.containerplacement.api_string
-                        self.obj['samples'][sample.name]['library_prep'][prepname]['library_validation'][agrlibval.luid]['reagent_labels'] = [rg.name for rg in inp_artifact.reagentlabels]
                         if 'By user' not in self.obj['details']['library_construction_method'] and len(inp_artifact.reagentlabels)==1:
                             # if finlib, these are already computed
                             self.obj['samples'][sample.name]['library_prep'][prepname]['reagent_label'] = inp_artifact.reagentlabels[0].name
@@ -837,7 +836,6 @@ class ProjectSQL:
                                 out_art = self.session.query(Artifact).from_statement(text(query)).one()
                                 self.obj['samples'][sample.name]['library_prep'][prepname]['prep_status'] = out_art.qc_flag
                                 self.obj['samples'][sample.name]['library_prep'][prepname]['library_validation'][agrlibval.luid]['prep_status'] = out_art.qc_flag
-                                self.obj['samples'][sample.name]['library_prep'][prepname]['library_validation'][agrlibval.luid]['reagent_labels'] = [rg.name for rg in out_art.reagentlabels]
 
                             except NoResultFound:
                                 self.log.info("Did not find the output resultfile of the Neoprep step for sample {}".format(sample.name))

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -385,7 +385,7 @@ class ProjectSQL:
         self.get_escalations()
         self.get_samples()
 
-    def save(self):
+    def save(self, update_modification_time=True):
         doc = None
         # When running for a single project, sometimes the connection is lost so retry
         try:
@@ -408,13 +408,20 @@ class ProjectSQL:
                 self.obj['_id'] = my_id
                 self.obj['_rev'] = my_rev
                 self.obj['creation_time'] = my_crea
-                self.obj['modification_time'] = datetime.now().isoformat()
+
+                if update_modification_time:
+                    self.obj['modification_time'] = datetime.now().isoformat()
+                else:
+                    self.obj['modification_time'] = my_mod
+
                 if my_staged_files:
                     self.obj['staged_files'] = my_staged_files
                 self.log.info("Trying to save new doc for project {}".format(self.pid))
                 db.save(self.obj)
 
         else:
+            self.obj['creation_time'] = datetime.now().isoformat()
+            self.obj['modification_time'] = self.obj['creation_time']
             self.log.info("Trying to save new doc for project {}".format(self.pid))
             db.save(self.obj)
 

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 import LIMS2DB.objectsDB.process_categories as pc_cg
 import re
+import httplib
 
 class Workset:
 
@@ -386,6 +387,12 @@ class ProjectSQL:
 
     def save(self):
         doc = None
+        # When running for a single project, sometimes the connection is lost so retry
+        try:
+            self.couch['projects']
+        except httplib.BadStatusLine:
+            self.log.warning("Access to couch failed before trying to save new doc for project {}".format(self.pid))
+            pass
         db = self.couch['projects']
         view = db.view('project/project_id')
         for row in view[self.pid]:

--- a/scripts/project_summary_upload_LIMS.py
+++ b/scripts/project_summary_upload_LIMS.py
@@ -139,7 +139,7 @@ def main(options):
                 pj_id=options.project_name
             P = ProjectSQL(lims_db, mainlog, pj_id, host, couch, oconf)
             if options.upload:
-                P.save()
+                P.save(update_modification_time=not options.no_new_modification_time)
             else:
                 if output_f is not None:
                     with open(output_f, 'w') as f:
@@ -392,6 +392,8 @@ if __name__ == '__main__':
     parser.add_option("-k", "--control", dest = "control", action="store_true", help = ("only perform a dry-run"), default=False)
     parser.add_option("-i", "--input", dest = "input", help = ("path to the input file containing projects to update"), default=None)
     parser.add_option("--old", dest = "old", help = ("use the old version of psul, via the API"), action="store_true", default=False)
+    parser.add_option("--no_new_modification_time", action="store_true", help=("This updates documents without changing the modification"
+                        " time. Slightly dangerous, but useful e.g. when all projects would be updated. Does not work together with '--old'"))
 
     (options, args) = parser.parse_args()
     main(options)


### PR DESCRIPTION
To list all reagent labels on each sample is a very inefficient way to store that information as it is listed over and over. For some projects the number of samples and reagent labels combined even broke the database. I suggest to remove this completely as we are not using it anywhere that I have been able to find. If we need it in the future the information is kept in the LIMS.

The samples database is no longer updated and I therefore removed a method where the id of the sample document was looked up. I've opted for keeping the key in the database, but use None for all values instead. This will be consistent with all projects from 2016 and on, but will change all projects before that.

To avoid changing the modification time for all projects for these changes, I added an option to skip updating the modification times. My plan is to run the script manually for all projects using this option. The crontab jobs will still update the modification times for any other types of modifications. The first step will however be to remove and regenerate the broken projects mentioned in the beginning.