### PR TITLE
Add status_fields to project documents

### DIFF
--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1081,7 +1081,6 @@ class ProjectSQL:
                         status_fields['ongoing'] = True
                         status_fields['open'] = True
 
-                        status_fields['need_review'] = False
                         status_fields['pending'] = False
                         status_fields['reception_control'] = False
                     else:
@@ -1091,7 +1090,6 @@ class ProjectSQL:
 
                         status_fields['ongoing'] = False
                         status_fields['pending'] = False
-                        status_fields['need_review'] = False
                 else:
                     if self.obj.get('order_date'):
                         status_fields['status'] = 'Pending'

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -389,6 +389,7 @@ class ProjectSQL:
         self.get_project_summary()
         self.get_escalations()
         self.get_samples()
+        self.set_status()
 
     def save(self, update_modification_time=True):
         doc = None
@@ -1042,3 +1043,65 @@ class ProjectSQL:
             if matches:
                 barcode = matches.group(0).replace('_','-')
         return barcode
+
+    def set_status(self):
+        proj_details = self.obj.get(['details'])
+        status_fields = {}
+
+        if self.obj.get('aborted'):
+            status_fields['status'] = 'Aborted'
+            status_fields['aborted'] = True
+            status_fields['closed'] = True
+
+            status_fields['ongoing'] = False
+            status_fields['open'] = False
+            status_fields['pending'] = False
+            status_fields['reception_control'] = False
+            status_fields['need_review'] = False
+
+        else:
+            status_fields['aborted'] = False
+            if self.obj.get('close_date'):
+                status_fields['status'] = 'Closed'
+                status_fields['closed'] = True
+
+                status_fields['ongoing'] = False
+                status_fields['open'] = False
+                status_fields['pending'] = False
+                status_fields['reception_control'] = False
+                status_fields['need_review'] = False
+            else:
+                status_fields['closed'] = True
+                if self.obj.get('open_date'):
+                    if self.obj.get('escalations'):
+                        status_fields['need_review'] = True
+
+                    if proj_details.get('queued'):
+                        status_fields['status'] = 'Ongoing'
+                        status_fields['ongoing'] = True
+                        status_fields['open'] = True
+
+                        status_fields['need_review'] = False
+                        status_fields['pending'] = False
+                        status_fields['reception_control'] = False
+                    else:
+                        status_fields['status'] = 'Reception Control'
+                        status_fields['reception_control'] = True
+                        status_fields['open'] = True
+
+                        status_fields['ongoing'] = False
+                        status_fields['pending'] = False
+                        status_fields['need_review'] = False
+                else:
+                    if self.obj.get('order_date'):
+                        status_fields['status'] = 'Pending'
+                        status_fields['pending'] = True
+
+                        status_fields['open'] = False
+                        status_fields['reception_control'] = False
+                        status_fields['ongoing'] = False
+                        status_fields['need_review'] = False
+                    else:
+                        raise ValueError('Project status data is invalid')
+
+        self.obj['status_fields'] = status_fields

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1048,7 +1048,7 @@ class ProjectSQL:
         proj_details = self.obj.get('details')
         status_fields = {}
 
-        if self.obj.get('aborted'):
+        if proj_details.get('aborted'):
             status_fields['status'] = 'Aborted'
             status_fields['aborted'] = True
             status_fields['closed'] = True

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1048,30 +1048,29 @@ class ProjectSQL:
         proj_details = self.obj.get('details')
         status_fields = {}
 
+        # Convenience string status field
+        status_fields['status'] = None
+
+        # Boolean status fields
+        status_fields['aborted'] = False
+        status_fields['closed'] = False
+        status_fields['ongoing'] = False
+        status_fields['open'] = False
+        status_fields['pending'] = False
+        status_fields['reception_control'] = False
+
+        # Tags
+        status_fields['need_review'] = False
+
         if proj_details.get('aborted'):
             status_fields['status'] = 'Aborted'
             status_fields['aborted'] = True
             status_fields['closed'] = True
-
-            status_fields['ongoing'] = False
-            status_fields['open'] = False
-            status_fields['pending'] = False
-            status_fields['reception_control'] = False
-            status_fields['need_review'] = False
-
         else:
-            status_fields['aborted'] = False
             if self.obj.get('close_date'):
                 status_fields['status'] = 'Closed'
                 status_fields['closed'] = True
-
-                status_fields['ongoing'] = False
-                status_fields['open'] = False
-                status_fields['pending'] = False
-                status_fields['reception_control'] = False
-                status_fields['need_review'] = False
             else:
-                status_fields['closed'] = False
                 if self.obj.get('open_date'):
                     if self.obj.get('escalations'):
                         status_fields['need_review'] = True
@@ -1080,26 +1079,15 @@ class ProjectSQL:
                         status_fields['status'] = 'Ongoing'
                         status_fields['ongoing'] = True
                         status_fields['open'] = True
-
-                        status_fields['pending'] = False
-                        status_fields['reception_control'] = False
                     else:
                         status_fields['status'] = 'Reception Control'
                         status_fields['reception_control'] = True
                         status_fields['open'] = True
-
-                        status_fields['ongoing'] = False
-                        status_fields['pending'] = False
                 else:
                     if proj_details.get('order_received'):
                         status_fields['status'] = 'Pending'
                         status_fields['pending'] = True
-
-                        status_fields['open'] = False
-                        status_fields['reception_control'] = False
-                        status_fields['ongoing'] = False
-                        status_fields['need_review'] = False
                     else:
-                        raise ValueError('Project status data is invalid')
+                        self.log.error("Project status data for {} is invalid.".format(self.obj['project_name']))
 
         self.obj['status_fields'] = status_fields

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1071,7 +1071,7 @@ class ProjectSQL:
                 status_fields['reception_control'] = False
                 status_fields['need_review'] = False
             else:
-                status_fields['closed'] = True
+                status_fields['closed'] = False
                 if self.obj.get('open_date'):
                     if self.obj.get('escalations'):
                         status_fields['need_review'] = True

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1091,7 +1091,7 @@ class ProjectSQL:
                         status_fields['ongoing'] = False
                         status_fields['pending'] = False
                 else:
-                    if self.obj.get('order_date'):
+                    if proj_details.get('order_received'):
                         status_fields['status'] = 'Pending'
                         status_fields['pending'] = True
 

--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1045,7 +1045,7 @@ class ProjectSQL:
         return barcode
 
     def set_status(self):
-        proj_details = self.obj.get(['details'])
+        proj_details = self.obj.get('details')
         status_fields = {}
 
         if self.obj.get('aborted'):


### PR DESCRIPTION
A new field 'status_fields' is added to project documents where all possible statuses and tags for a project is present as booleans. For convenience I included the 'status' key as well which should display what is considered the current status of the project. This would correspond to the label badge on genomics status, for example 'Closed' for this project:
<img width="686" alt="Screenshot 2021-04-22 at 11 32 21" src="https://user-images.githubusercontent.com/1250075/115691503-6a439780-a35e-11eb-8c71-0383c2600626.png">


In attempt to make the code easily readable it became a bit too verbose perhaps? I want this code to be easy to read and understand, it doesn't have to be very efficient. Suggestions are welcome!