### PR TITLE
Found another place where queued can be set

### DIFF
--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1079,6 +1079,10 @@ class ProjectSQL:
                         status_fields['status'] = 'Ongoing'
                         status_fields['ongoing'] = True
                         status_fields['open'] = True
+                    elif self.obj.get('project_summary', {}).get('queued'):
+                        status_fields['status'] = 'Ongoing'
+                        status_fields['ongoing'] = True
+                        status_fields['open'] = True
                     else:
                         status_fields['status'] = 'Reception Control'
                         status_fields['reception_control'] = True


### PR DESCRIPTION
The 'queued' field is either set in project_details or in the project_summary. The status_fields recently added did not take the second alternative into account, so some projects are missclassified, such as: https://genomics-status-stage.scilifelab.se/project/P20313

This should fix the issue. 