### PR TITLE
Use date field rather than parsing runname, meaning run name can be more flexible

### DIFF
--- a/LIMS2DB/classes.py
+++ b/LIMS2DB/classes.py
@@ -1126,7 +1126,10 @@ class ProjectSQL:
                             date = run_name.split('_')[0]
                             samp_run_met_id = run_name
                             self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id] = {}
-                            self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['sequencing_start_date'] = f"{date[:4]}-{date[4:6]}-{date[6:]}"      
+                            try:
+                                self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['sequencing_start_date'] = seqstarts[0].daterun.strftime("%Y-%m-%d")
+                            except AttributeError:
+                                self.obj['samples'][sample.name]['library_prep'][prepname]['sample_run_metrics'][samp_run_met_id]['sequencing_start_date'] = seqstarts[0].createddate.strftime("%Y-%m-%d")   
      
 
     def extract_barcode(self, chain):


### PR DESCRIPTION
There was a fake run name `*_3A_230525A_*` that caused issues because the name wasn't in the intended format. Getting the date from an actual date field would help us avoid this and make naming be a bit more flexible if we want it to be.