### PR TITLE
Change versioning to be compatible with PEP 440 which setuptools enforces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import glob
 import subprocess
 
 def get_version():
-    return "1.0-{}".format(subprocess.check_output(["git", "rev-parse", "HEAD"]))
+    return "1.0+{}".format(subprocess.check_output(["git", "rev-parse", "HEAD"]))
 try:
     with open("requirements.txt", "r") as f:
         install_requires = [x.strip() for x in f.readlines()]


### PR DESCRIPTION
The latest versions of setuptools enforces strict versioning with PEP 440